### PR TITLE
libssh2 1.11.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,1 @@
+aggregate_check: false

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,1 +1,0 @@
-aggregate_check: false

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -5,11 +5,18 @@ set CXXFLAGS=
 
 mkdir build
 pushd build
-  cmake .. -G "%CMAKE_GENERATOR%"                     ^
-           -DCMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX%  ^
-           -DCMAKE_BUILD_TYPE=Release               ^
-           -DBUILD_SHARED_LIBS=ON
-  cmake --build . --config Release --target INSTALL
-  REM The most of the tests fails becasue of 'Test command: NOT_AVAILABLE'
-  ::ctest -VV --output-on-failure
+  cmake .. -GNinja                           ^
+    -DCMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX%  ^
+    -DCMAKE_BUILD_TYPE=Release               ^
+    -DBUILD_SHARED_LIBS=ON                   ^
+    -D CMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ^
+    -D CMAKE_PREFIX_PATH=%LIBRARY_PREFIX%    ^
+    -D ENABLE_ZLIB_COMPRESSION=ON            ^
+    -D BUILD_EXAMPLES=OFF                    ^
+    -D BUILD_TESTING=OFF
+
+  ninja
+  IF %ERRORLEVEL% NEQ 0 exit 1
+  ninja install
+  IF %ERRORLEVEL% NEQ 0 exit 1
 popd

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -15,7 +15,7 @@ pushd build
     -D ENABLE_ZLIB_COMPRESSION=ON            ^
     -D BUILD_EXAMPLES=OFF                    ^
     -DBUILD_TESTING=ON                       ^
-    -DRUN_DOCKER_TESTS=OFF                   ^
+    -DRUN_DOCKER_TESTS=OFF
 
   ninja -j%CPU_COUNT%
   IF %ERRORLEVEL% NEQ 0 exit 1

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -9,14 +9,16 @@ pushd build
     -DCMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX%  ^
     -DCMAKE_BUILD_TYPE=Release               ^
     -DBUILD_SHARED_LIBS=ON                   ^
-    -D BUILD_STATIC_LIBS=OFF                 ^
-    -D CMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ^
-    -D CMAKE_PREFIX_PATH=%LIBRARY_PREFIX%    ^
-    -D ENABLE_ZLIB_COMPRESSION=ON            ^
-    -D BUILD_EXAMPLES=OFF                    ^
+    -DBUILD_STATIC_LIBS=OFF                  ^
+    -DCMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX%  ^
+    -DCMAKE_PREFIX_PATH=%LIBRARY_PREFIX%     ^
+    -DENABLE_ZLIB_COMPRESSION=ON             ^
+    -DCRYPTO_BACKEND=OpenSSL                 ^
+    -DBUILD_EXAMPLES=OFF                     ^
     -DBUILD_TESTING=ON                       ^
     -DRUN_DOCKER_TESTS=OFF                   ^
-    -DRUN_SSHD_TESTS=OFF
+    -DRUN_SSHD_TESTS=OFF                     ^
+    %CMAKE_ARGS%
 
   ninja -j%CPU_COUNT%
   IF %ERRORLEVEL% NEQ 0 exit 1

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -16,7 +16,7 @@ pushd build
     -D BUILD_EXAMPLES=OFF                    ^
     -D BUILD_TESTING=OFF
 
-  ninja
+  ninja -j%CPU_COUNT%
   IF %ERRORLEVEL% NEQ 0 exit 1
   ninja install
   IF %ERRORLEVEL% NEQ 0 exit 1

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -14,9 +14,12 @@ pushd build
     -D CMAKE_PREFIX_PATH=%LIBRARY_PREFIX%    ^
     -D ENABLE_ZLIB_COMPRESSION=ON            ^
     -D BUILD_EXAMPLES=OFF                    ^
-    -D BUILD_TESTING=OFF
+    -DBUILD_TESTING=ON                       ^
+    -DRUN_DOCKER_TESTS=OFF                   ^
 
   ninja -j%CPU_COUNT%
+  IF %ERRORLEVEL% NEQ 0 exit 1
+  ctest --output-on-failure
   IF %ERRORLEVEL% NEQ 0 exit 1
   ninja install
   IF %ERRORLEVEL% NEQ 0 exit 1

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -9,6 +9,7 @@ pushd build
     -DCMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX%  ^
     -DCMAKE_BUILD_TYPE=Release               ^
     -DBUILD_SHARED_LIBS=ON                   ^
+    -D BUILD_STATIC_LIBS=OFF                 ^
     -D CMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ^
     -D CMAKE_PREFIX_PATH=%LIBRARY_PREFIX%    ^
     -D ENABLE_ZLIB_COMPRESSION=ON            ^

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -10,4 +10,5 @@ pushd build
            -DCMAKE_BUILD_TYPE=Release               ^
            -DBUILD_SHARED_LIBS=ON
   cmake --build . --config Release --target INSTALL
+  ctest -VV --output-on-failure
 popd

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -10,5 +10,6 @@ pushd build
            -DCMAKE_BUILD_TYPE=Release               ^
            -DBUILD_SHARED_LIBS=ON
   cmake --build . --config Release --target INSTALL
-  ctest -VV --output-on-failure
+  REM The most of the tests fails becasue of 'Test command: NOT_AVAILABLE'
+  ::ctest -VV --output-on-failure
 popd

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -15,10 +15,12 @@ pushd build
     -D ENABLE_ZLIB_COMPRESSION=ON            ^
     -D BUILD_EXAMPLES=OFF                    ^
     -DBUILD_TESTING=ON                       ^
-    -DRUN_DOCKER_TESTS=OFF
+    -DRUN_DOCKER_TESTS=OFF                   ^
+    -DRUN_SSHD_TESTS=OFF
 
   ninja -j%CPU_COUNT%
   IF %ERRORLEVEL% NEQ 0 exit 1
+  REM Skip Docker and SSHD tests (see above) because they involve external dependencies
   ctest --output-on-failure
   IF %ERRORLEVEL% NEQ 0 exit 1
   ninja install

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -22,11 +22,12 @@ for _shared in OFF ON; do
           -DCRYPTO_BACKEND=OpenSSL          \
           -DENABLE_ZLIB_COMPRESSION=ON      \
           -DBUILD_EXAMPLES=OFF              \
-          -DBUILD_TESTING=OFF               \
+          -DBUILD_TESTING=ON                \
+          -DRUN_DOCKER_TESTS=OFF            \
           ..
     make -j${CPU_COUNT} ${VERBOSE_CM}
+    ctest --output-on-failure
     make install
     # ctest fails on the docker image 'sh: docker: command not found'
-    # ctest -VV --output-on-failure
   popd || exit
 done

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -22,5 +22,6 @@ for _shared in OFF ON; do
           ..
     make -j${CPU_COUNT} ${VERBOSE_CM}
     make install
+    ctest -VV --output-on-failure
   popd
 done

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -22,6 +22,7 @@ for _shared in OFF ON; do
           ..
     make -j${CPU_COUNT} ${VERBOSE_CM}
     make install
-    ctest -VV --output-on-failure
+    # The most of the tests fails becasue of 'sh: docker: command not found'
+    # ctest -VV --output-on-failure
   popd
 done

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -24,8 +24,10 @@ for _shared in OFF ON; do
           -DBUILD_EXAMPLES=OFF              \
           -DBUILD_TESTING=ON                \
           -DRUN_DOCKER_TESTS=OFF            \
+          -DRUN_SSHD_TESTS=OFF              \
           ..
     make -j${CPU_COUNT} ${VERBOSE_CM}
+    # Skip Docker and SSHD tests (see above) because they involve external dependencies
     ctest --output-on-failure
     make install
     # ctest fails on the docker image 'sh: docker: command not found'

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -12,24 +12,25 @@ if [[ "${target_platform}" == linux-aarch64 ]]; then
   fi
 fi
 
-for _shared in OFF ON; do
-  mkdir build-${_shared}
-  pushd build-${_shared} || exit
-    cmake ${CMAKE_ARGS}                     \
-          -DCMAKE_INSTALL_PREFIX=${PREFIX}  \
-          -DBUILD_SHARED_LIBS=${_shared}    \
-          -DCMAKE_INSTALL_LIBDIR=lib        \
-          -DCRYPTO_BACKEND=OpenSSL          \
-          -DENABLE_ZLIB_COMPRESSION=ON      \
-          -DBUILD_EXAMPLES=OFF              \
-          -DBUILD_TESTING=ON                \
-          -DRUN_DOCKER_TESTS=OFF            \
-          -DRUN_SSHD_TESTS=OFF              \
-          ..
-    make -j${CPU_COUNT} ${VERBOSE_CM}
-    # Skip Docker and SSHD tests (see above) because they involve external dependencies
-    ctest --output-on-failure
-    make install
-    # ctest fails on the docker image 'sh: docker: command not found'
-  popd || exit
-done
+mkdir build-shared
+pushd build-shared || exit
+  cmake -GNinja  \
+        ${CMAKE_ARGS}                     \
+        -DCMAKE_INSTALL_PREFIX=${PREFIX}  \
+        -DBUILD_SHARED_LIBS=ON            \
+        -DBUILD_STATIC_LIBS=OFF           \
+        -DCMAKE_INSTALL_LIBDIR=lib        \
+        -DCRYPTO_BACKEND=OpenSSL          \
+        -DENABLE_ZLIB_COMPRESSION=ON      \
+        -DBUILD_EXAMPLES=OFF              \
+        -DBUILD_TESTING=ON                \
+        -DRUN_DOCKER_TESTS=OFF            \
+        -DRUN_SSHD_TESTS=OFF              \
+        ..
+
+  ninja -j${CPU_COUNT} ${VERBOSE_CM}
+  # Skip Docker and SSHD tests (see above) because they involve external dependencies
+  ctest --output-on-failure
+  ninja install
+  # ctest fails on the docker image 'sh: docker: command not found'
+popd || exit

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -28,7 +28,7 @@ pushd build-shared || exit
         -DRUN_SSHD_TESTS=OFF              \
         ..
 
-  ninja -j${CPU_COUNT} ${VERBOSE_CM}
+  ninja -j${CPU_COUNT}
   # Skip Docker and SSHD tests (see above) because they involve external dependencies
   ctest --output-on-failure
   ninja install

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -14,15 +14,19 @@ fi
 
 for _shared in OFF ON; do
   mkdir build-${_shared}
-  pushd build-${_shared}
+  pushd build-${_shared} || exit
     cmake ${CMAKE_ARGS}                     \
           -DCMAKE_INSTALL_PREFIX=${PREFIX}  \
           -DBUILD_SHARED_LIBS=${_shared}    \
           -DCMAKE_INSTALL_LIBDIR=lib        \
+          -DCRYPTO_BACKEND=OpenSSL          \
+          -DENABLE_ZLIB_COMPRESSION=ON      \
+          -DBUILD_EXAMPLES=OFF              \
+          -DBUILD_TESTING=OFF               \
           ..
     make -j${CPU_COUNT} ${VERBOSE_CM}
     make install
-    # The most of the tests fails becasue of 'sh: docker: command not found'
+    # ctest fails on the docker image 'sh: docker: command not found'
     # ctest -VV --output-on-failure
-  popd
+  popd || exit
 done

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,7 +22,6 @@ requirements:
     - cmake-no-system
     - ninja-base  # [win]
     - make        # [unix]
-    - pkg-config
   host:
     - openssl {{ openssl }}
     - zlib {{ zlib }}
@@ -35,7 +34,7 @@ test:
     - test -f $PREFIX/include/libssh2.h              # [not win]
     - test -f $PREFIX/include/libssh2_publickey.h    # [not win]
     - test -f $PREFIX/include/libssh2_sftp.h         # [not win]
-    
+
     - test -f $PREFIX/lib/libssh2.a                  # [not win]
     - test -f $PREFIX/lib/libssh2${SHLIB_EXT}        # [not win]
     - test -f $PREFIX/lib/pkgconfig/libssh2.pc       # [not win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,7 +35,6 @@ test:
     - test -f $PREFIX/include/libssh2_publickey.h    # [not win]
     - test -f $PREFIX/include/libssh2_sftp.h         # [not win]
 
-    - test -f $PREFIX/lib/libssh2.a                  # [not win]
     - test -f $PREFIX/lib/libssh2${SHLIB_EXT}        # [not win]
     - test -f $PREFIX/lib/pkgconfig/libssh2.pc       # [not win]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,15 +1,16 @@
-{% set version = "1.10.0" %}
+{% set name = "libssh2" %}
+{% set version = "1.11.0" %}
 
 package:
-  name: libssh2
+  name: {{ name }}
   version: {{ version }}
 
 source:
-  url: https://www.libssh2.org/download/libssh2-{{ version }}.tar.gz
-  sha256: 2d64e90f3ded394b91d3a2e774ca203a4179f69aebee03003e5a6fa621e41d51
+  url: https://www.libssh2.org/download/{{ name }}-{{ version }}.tar.gz
+  sha256: 3736161e41e2693324deb38c26cfdc3efe6209d634ba4258db1cecff6a5ad461
 
 build:
-  number: 3
+  number: 0
   run_exports:
     - {{ pin_subpackage('libssh2') }}
 
@@ -33,11 +34,14 @@ test:
     
     - test -f $PREFIX/lib/libssh2.a                  # [not win]
     - test -f $PREFIX/lib/libssh2${SHLIB_EXT}        # [not win]
+    - test -f $PREFIX/lib/pkgconfig/libssh2.pc       # [not win]
 
-    - if not exist %LIBRARY_INC%\\libssh2.h           exit 1  # [win]
-    - if not exist %LIBRARY_INC%\\libssh2_publickey.h exit 1  # [win]
-    - if not exist %LIBRARY_INC%\\libssh2_sftp.h      exit 1  # [win]
-    - if not exist %LIBRARY_LIB%\\libssh2.lib         exit 1  # [win]
+    - if not exist %LIBRARY_INC%\\libssh2.h             exit 1  # [win]
+    - if not exist %LIBRARY_INC%\\libssh2_publickey.h   exit 1  # [win]
+    - if not exist %LIBRARY_INC%\\libssh2_sftp.h        exit 1  # [win]
+    - if not exist %LIBRARY_LIB%\\libssh2.lib           exit 1  # [win]
+    - if not exist %LIBRARY_LIB%\\pkgconfig\\libssh2.pc exit 1  # [win]
+    - if not exist %LIBRARY_INC%\\libssh2.dll           exit 1  # [win]
 
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,14 +17,17 @@ build:
 requirements:
   build:
     - {{ compiler('c') }}
-    - make   # [unix]
+    - ninja-base  # [win]
+    - make        # [unix]
     # This breaks a dependency cycle:
     # curl->libssh2->cmake->curl
     - cmake-no-system
   host:
     - openssl {{ openssl }}
+    - zlib {{ zlib }}
   run:
     - openssl  # exact pin handled through openssl run_exports
+    - zlib
 
 test:
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,11 +17,12 @@ build:
 requirements:
   build:
     - {{ compiler('c') }}
-    - ninja-base  # [win]
-    - make        # [unix]
     # This breaks a dependency cycle:
     # curl->libssh2->cmake->curl
     - cmake-no-system
+    - ninja-base  # [win]
+    - make        # [unix]
+    - pkg-config
   host:
     - openssl {{ openssl }}
     - zlib {{ zlib }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,8 +20,7 @@ requirements:
     # This breaks a dependency cycle:
     # curl->libssh2->cmake->curl
     - cmake-no-system
-    - ninja-base  # [win]
-    - make        # [unix]
+    - ninja-base
   host:
     - openssl {{ openssl }}
     - zlib {{ zlib }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,13 +40,12 @@ test:
     - test -f $PREFIX/lib/libssh2${SHLIB_EXT}        # [not win]
     - test -f $PREFIX/lib/pkgconfig/libssh2.pc       # [not win]
 
-    - if not exist %LIBRARY_INC%\\libssh2.h             exit 1  # [win]
-    - if not exist %LIBRARY_INC%\\libssh2_publickey.h   exit 1  # [win]
-    - if not exist %LIBRARY_INC%\\libssh2_sftp.h        exit 1  # [win]
-    - if not exist %LIBRARY_LIB%\\libssh2.lib           exit 1  # [win]
+    - if not exist %LIBRARY_INC%\\libssh2.h exit 1              # [win]
+    - if not exist %LIBRARY_INC%\\libssh2_publickey.h exit 1    # [win]
+    - if not exist %LIBRARY_INC%\\libssh2_sftp.h exit 1         # [win]
+    - if not exist %LIBRARY_LIB%\\libssh2.lib exit 1            # [win]
     - if not exist %LIBRARY_LIB%\\pkgconfig\\libssh2.pc exit 1  # [win]
-    - if not exist %LIBRARY_INC%\\libssh2.dll           exit 1  # [win]
-
+    - if not exist %LIBRARY_BIN%\\libssh2.dll exit 1            # [win]
 
 about:
   home: https://www.libssh2.org/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,7 +25,8 @@ requirements:
     - openssl {{ openssl }}
     - zlib {{ zlib }}
   run:
-    - openssl  # exact pin handled through openssl run_exports
+    # exact pin handled through openssl and zlib run_exports
+    - openssl
     - zlib
 
 test:


### PR DESCRIPTION
**Destination channel:** main

### Links

- [PKG-4628](https://anaconda.atlassian.net/browse/PKG-4628) 
- [Upstream repository](https://github.com/libssh2/libssh2/tree/libssh2-1.11.0)
- Release notes: https://github.com/libssh2/libssh2/releases
- Requirements:
  - https://github.com/libssh2/libssh2/blob/libssh2-1.11.0/CMakeLists.txt 

### Explanation of changes:

- Use `ninja` on `win64` instead of `CMAKE_GENERATOR`
- Add new Cmake flags based on conda-forge recipe: 
  - disable tests as they are not working due to the `docker` command, 
  - disable examples, 
  - explicitly define the crypto backend `openssl` and enable `zlib` compression as it's [required](https://github.com/libssh2/libssh2/blob/libssh2-1.11.0/CMakeLists.txt#L347-L352) with `openssl`, 
  - disable _static_ library on `win` as we didn't provide it for the [current v1.10.0](https://conda-metadata-app.streamlit.app/?q=pkgs%2Fmain%2Fwin-64%2Flibssh2-1.10.0-he2ea4bf_3.conda) but we still include the static library on [unix](https://conda-metadata-app.streamlit.app/?q=pkgs%2Fmain%2Flinux-64%2Flibssh2-1.10.0-hdbd6064_3.conda)
- Add `zlib` to `host` and `run`
- Add more test commands 


[PKG-4628]: https://anaconda.atlassian.net/browse/PKG-4628?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ